### PR TITLE
Replace substr with mb_substr for UTF-8 support

### DIFF
--- a/src/Payment/Aggregates/Address.php
+++ b/src/Payment/Aggregates/Address.php
@@ -117,7 +117,7 @@ final class Address extends AbstractEntity implements ConvertibleToSDKRequestsIn
             $streetWithoutComma
         );
 
-        $this->street = substr($streetWithoutLineBreaks, 0, 64);
+        $this->street = mb_substr($streetWithoutLineBreaks, 0, 64, 'UTF-8');
 
         if (empty($this->street)) {
             $inputName = $this->i18n->getDashboard('street');
@@ -157,7 +157,7 @@ final class Address extends AbstractEntity implements ConvertibleToSDKRequestsIn
             $neighborhoodWithoutComma
         );
 
-        $this->neighborhood = substr($neighborhoodWithoutLineBreaks, 0, 64);
+        $this->neighborhood = mb_substr($neighborhoodWithoutLineBreaks, 0, 64, 'UTF-8');
 
         if (empty($this->neighborhood)) {
 
@@ -188,7 +188,7 @@ final class Address extends AbstractEntity implements ConvertibleToSDKRequestsIn
     public function setComplement($complement)
     {
         $complementWithoutLineBreaks = StringFunctionsHelper::removeLineBreaks($complement);
-        $this->complement = substr($complementWithoutLineBreaks, 0, 64);
+        $this->complement = mb_substr($complementWithoutLineBreaks, 0, 64, 'UTF-8');
         return $this;
     }
 
@@ -239,7 +239,7 @@ final class Address extends AbstractEntity implements ConvertibleToSDKRequestsIn
     public function setCity($city)
     {
         $this->city = trim(
-            substr($city, 0, 64)
+            mb_substr($city, 0, 64, 'UTF-8')
         );
 
         if (empty($this->city)) {
@@ -271,7 +271,7 @@ final class Address extends AbstractEntity implements ConvertibleToSDKRequestsIn
      */
     public function setCountry($country)
     {
-        $this->country = substr($country, 0, 2);
+        $this->country = mb_substr($country, 0, 2, 'UTF-8');
 
         if (empty($this->country)) {
 
@@ -317,7 +317,7 @@ final class Address extends AbstractEntity implements ConvertibleToSDKRequestsIn
      */
     public function setState($state)
     {
-        $this->state = substr($state, 0, 2);
+        $this->state = mb_substr($state, 0, 2, 'UTF-8');
 
         if (empty($this->state)) {
 

--- a/src/Payment/Aggregates/Customer.php
+++ b/src/Payment/Aggregates/Customer.php
@@ -64,7 +64,7 @@ final class Customer extends AbstractEntity implements ConvertibleToSDKRequestsI
      */
     public function setName($name)
     {
-        $this->name = substr($name ?? "", 0, 64);
+        $this->name = mb_substr($name ?? "", 0, 64, 'UTF-8');
     }
 
     /**

--- a/src/Payment/Aggregates/Item.php
+++ b/src/Payment/Aggregates/Item.php
@@ -51,7 +51,7 @@ final class Item extends AbstractEntity implements ConvertibleToSDKRequestsInter
      */
     public function setDescription($description)
     {
-        $this->description = substr($description, 0, 256);
+        $this->description = mb_substr($description, 0, 256, 'UTF-8');
     }
 
     /**

--- a/src/Payment/Aggregates/Shipping.php
+++ b/src/Payment/Aggregates/Shipping.php
@@ -34,7 +34,7 @@ final class Shipping extends AbstractEntity implements ConvertibleToSDKRequestsI
      */
     public function setDescription($description)
     {
-        $this->description = substr($description, 0, 64);
+        $this->description = mb_substr($description, 0, 64, 'UTF-8');
     }
 
     /**
@@ -50,7 +50,7 @@ final class Shipping extends AbstractEntity implements ConvertibleToSDKRequestsI
      */
     public function setRecipientName($recipientName)
     {
-        $this->recipientName = substr($recipientName, 0, 64);
+        $this->recipientName = mb_substr($recipientName, 0, 64, 'UTF-8');
     }
 
     /**

--- a/src/Recurrence/Aggregates/SubProduct.php
+++ b/src/Recurrence/Aggregates/SubProduct.php
@@ -108,7 +108,7 @@ class SubProduct extends AbstractEntity implements SubProductEntityInterface
      */
     public function setDescription($description)
     {
-        $description = substr(strip_tags($description), 0, 256);
+        $description = mb_substr(strip_tags($description), 0, 256, 'UTF-8');
 
         $this->description = $description;
         return $this;
@@ -133,7 +133,7 @@ class SubProduct extends AbstractEntity implements SubProductEntityInterface
             $name = preg_replace('/[^a-zA-Z0-9 ]+/i', '', $name ?? '');
         }
 
-        $this->name = substr($name, 0, 256);
+        $this->name = mb_substr($name, 0, 256, 'UTF-8');
         return $this;
     }
 


### PR DESCRIPTION
Erro:  Warning: Undefined array key "status" in /vendor/pagarme/ecommerce-module-core/src/Kernel/Factories/OrderFactory.php on line 31


Para conseguir reproduzir o erro: Tente criar uma compra onde a soma de caracteres de: firstName, middleName, e lastName, são maiores que 64, e há acentuação.


Este problema estava causando erros na requisição de compra para a api da pagarme. ao lidar com palavras com acento. Ao usar `mb_substr`, garantimos que os caracteres multibyte sejam tratados corretamente, prevenindo erros de codificação ao chamar a API da pagarme.

![image](https://github.com/robsoned/ecommerce-module-core/assets/18008565/bfea8294-5896-4f9e-87ba-1e2954de6002)
